### PR TITLE
Trim whitespace on apply search

### DIFF
--- a/src/app/public/modules/search/search.component.spec.ts
+++ b/src/app/public/modules/search/search.component.spec.ts
@@ -249,6 +249,12 @@ describe('Search component', () => {
     expect(component.lastSearchTextApplied).toBe('applied text');
   });
 
+  it('should trim search text on apply button press', () => {
+    setInput('  applied text   ');
+    triggerApplyButton();
+    expect(component.lastSearchTextApplied).toBe('applied text');
+  });
+
   it('should emit search change event on ngModel change', () => {
     setNgModel('change text');
     fixture.detectChanges();

--- a/src/app/public/modules/search/search.component.ts
+++ b/src/app/public/modules/search/search.component.ts
@@ -179,6 +179,7 @@ export class SkySearchComponent implements OnDestroy, OnInit, OnChanges {
   }
 
   public applySearchText(searchText: string) {
+    searchText = searchText.trim();
     if (searchText !== this.searchText) {
       this.searchText = searchText;
     }


### PR DESCRIPTION
Trim extra whitespace from the front and back of search input when the search text is applied.

Addresses: #29 