### PR TITLE
Fix various country field bugs

### DIFF
--- a/src/app/public/modules/country-field/country-field.component.html
+++ b/src/app/public/modules/country-field/country-field.component.html
@@ -1,42 +1,38 @@
-<div
-  class="sky-form-group"
+<span
+  class="sky-country-field-container"
+  [ngClass]="{
+    'sky-country-field-disabled': disabled
+  }"
 >
-  <span
-    class="sky-country-field-container"
-    [ngClass]="{
-      'sky-country-field-disabled': disabled
-    }"
+  <sky-autocomplete
+    [data]="countries"
+    [propertiesToSearch]="['name', 'iso2']"
+    [searchResultTemplate]="countrySearchResultTemplate"
+    [searchTextMinimumCharacters]="searchTextMinimumCharacters"
+    (selectionChange)="onCountrySelected($event)"
   >
-    <sky-autocomplete
-      [data]="countries"
-      [propertiesToSearch]="['name', 'iso2']"
-      [searchResultTemplate]="countrySearchResultTemplate"
-      [searchTextMinimumCharacters]="searchTextMinimumCharacters"
-      (selectionChange)="onCountrySelected($event)"
+    <div
+      class="sky-form-control sky-country-field-input"
+      [ngClass]="{
+        'sky-field-status-active': isInputFocused
+      }"
     >
-      <div
-        class="sky-form-control sky-country-field-input"
-        [ngClass]="{
-          'sky-field-status-active': isInputFocused
-        }"
-      >
-        <div *ngIf="selectedCountry && selectedCountry.iso2 && !isInPhoneField"
-          [className]="'sky-country-field-flag iti-flag ' + selectedCountry.iso2.toLowerCase()"
-        ></div>
-        <textarea
-          skyAutocomplete
-          name="selectedCountry"
-          [attr.aria-label]="'skyux_country_field_search_placeholder' | skyLibResources"
-          [attr.disabled]="disabled ? true : undefined"
-          [formControl]="countrySearchFormControl"
-          [placeholder]="'skyux_country_field_search_placeholder' | skyLibResources"
-          (blur)="onAutocompleteBlur()"
-          #countrySearchInput
-        ></textarea>
-      </div>
-    </sky-autocomplete>
-  </span>
-</div>
+      <div *ngIf="selectedCountry && selectedCountry.iso2 && !isInPhoneField"
+        [className]="'sky-country-field-flag iti-flag ' + selectedCountry.iso2.toLowerCase()"
+      ></div>
+      <textarea
+        skyAutocomplete
+        name="selectedCountry"
+        [attr.aria-label]="'skyux_country_field_search_placeholder' | skyLibResources"
+        [attr.disabled]="disabled ? true : undefined"
+        [formControl]="countrySearchFormControl"
+        [placeholder]="'skyux_country_field_search_placeholder' | skyLibResources"
+        (blur)="onAutocompleteBlur()"
+        #countrySearchInput
+      ></textarea>
+    </div>
+  </sky-autocomplete>
+</span>
 
 <ng-template
   let-item="item"

--- a/src/app/public/modules/country-field/country-field.component.ts
+++ b/src/app/public/modules/country-field/country-field.component.ts
@@ -169,10 +169,6 @@ export class SkyCountryFieldComponent implements ControlValueAccessor, OnDestroy
       .intlTelInputGlobals.getCountryData()));
 
     this.countrySearchFormControl = new FormControl();
-
-    this.isInPhoneField = (<HTMLElement>elRef.nativeElement.parentElement)
-      .classList
-      .contains('sky-phone-field-country-search');
   }
 
   /**
@@ -193,6 +189,10 @@ export class SkyCountryFieldComponent implements ControlValueAccessor, OnDestroy
       });
 
     this.addEventListeners();
+
+    this.isInPhoneField = (<HTMLElement>this.elRef.nativeElement.parentElement)
+      .classList
+      .contains('sky-phone-field-country-search');
   }
 
   /**
@@ -267,6 +267,7 @@ export class SkyCountryFieldComponent implements ControlValueAccessor, OnDestroy
     if (!this.disabled) {
       this.selectedCountry = value;
     }
+    this.changeDetector.markForCheck();
   }
 
   private addEventListeners(): void {


### PR DESCRIPTION
Fixes 3 issues

1. Unnecessary form group style div which was causing an extra 10 px bottom margin
2. Fixed phone field check to happen in ngOnInit as it being in the constructor can cause the parents not to be recognized
3. Fixed `writeValue` to trigger change detection. Without this the flag might not disappear when the outer form is reset and/or cleared out.