### PR TITLE
Ensure search animation styles are properly removed.

### DIFF
--- a/src/app/public/modules/search/search-adapter.service.ts
+++ b/src/app/public/modules/search/search-adapter.service.ts
@@ -30,7 +30,7 @@ export class SkySearchAdapterService {
 
   public endInputAnimation(searchEl: ElementRef) {
     this.renderer.setStyle(this.getInputContainerEl(searchEl),
-      'min-width', undefined);
+      'min-width', '');
   }
 
   private getInputContainerEl(searchEl: ElementRef) {

--- a/src/app/public/modules/search/search.component.spec.ts
+++ b/src/app/public/modules/search/search.component.spec.ts
@@ -422,6 +422,19 @@ describe('Search component', () => {
 
       }));
     });
+
+    it('should remove the min-width property after animating', async(() => {
+      triggerXsBreakpoint().then(() => {
+        fixture.detectChanges();
+        let containerEl: HTMLElement = element.query(By.css('.sky-search-input-container')).nativeElement;
+          expect(containerEl.style.minWidth).toBeFalsy();
+        triggerLgBreakpoint().then(() => {
+          verifySearchOpenFullScreen();
+          containerEl = element.query(By.css('.sky-search-input-container')).nativeElement;
+          expect(containerEl.style.minWidth).toBeFalsy();
+        });
+      });
+    }));
   });
 
   describe('expandMode none', () => {


### PR DESCRIPTION
#56

I used this code to reproduce locally

```
<sky-fluid-grid>
  <sky-row>
    <sky-column screenLarge="6">
      <div style="background-color: blue; height: 200px">
        <div style="width: 50%">
          <sky-search
            [searchText]="searchText"
            (searchApply)="applySearchText(searchText)">
          </sky-search>
        </div>
      </div>
    </sky-column>
    <sky-column screenLarge="6">
      <div style="background-color: blue; height: 200px">
        <div style="width: 50%">
          <sky-search
            [searchText]="searchText"
            (searchApply)="applySearchText(searchText)">
          </sky-search>
        </div>
      </div>
    </sky-column>
  </sky-row>
</sky-fluid-grid>
```