### PR TITLE
Fix peerDependency version on skyux-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1500,9 +1500,9 @@
       "dev": true
     },
     "@skyux/core": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/@skyux/core/-/core-3.14.1.tgz",
-      "integrity": "sha512-mCOLf9yR2pqaUD6zKqOPa0Gy+3oqUMg9ihMJTRIWTyr8ZPE+oRcQUTZhLdjK4EN4chOvebOxW1jHeaU6ha1Zsg==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@skyux/core/-/core-3.14.2.tgz",
+      "integrity": "sha512-XRDuYh4jAASwUydptcuxT0RAoGK97PArYDk+lwmLfA38VwJhlYaQldZ7a0EruxhFpScniL4iVFGJ+q7lWGQVnA==",
       "dev": true
     },
     "@skyux/docs-tools": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@angular/common": ">=4.3.6",
     "@angular/core": ">=4.3.6",
     "@angular/router": ">=4.3.6",
-    "@skyux/core": "^3.5.1",
+    "@skyux/core": "^3.14.2",
     "@skyux/i18n": "^3.5.0",
     "@skyux/indicators": "^3.0.0"
   },
@@ -56,7 +56,7 @@
     "@skyux/animations": "3.0.0",
     "@skyux/assets": "3.1.0",
     "@skyux/config": "3.8.1",
-    "@skyux/core": "3.14.1",
+    "@skyux/core": "3.14.2",
     "@skyux/docs-tools": "3.2.0",
     "@skyux/forms": "3.6.3",
     "@skyux/http": "3.9.0",


### PR DESCRIPTION
I think the peerDependency list for this package should require a version of skyux-core which has the SkyAffixer and SkyOverlayService - if I'm totally wrong on this feel free to abandon the PR!