### PR TITLE
Update the country field fixture to return an array of country names …

### DIFF
--- a/src/app/public/testing/country-field/country-field-fixture.spec.ts
+++ b/src/app/public/testing/country-field/country-field-fixture.spec.ts
@@ -8,8 +8,7 @@ import {
 } from '@angular/core';
 
 import {
-  expect,
-  SkyAppTestUtility
+  expect
 } from '@skyux-sdk/testing';
 
 import {
@@ -192,8 +191,6 @@ describe('Country field fixture', () => {
 
     // verify the top result is as expected
     const topResult = results[0];
-    const countryNameEl = topResult.querySelector('.sky-highlight-mark');
-    const countryName = SkyAppTestUtility.getText(countryNameEl);
-    expect(countryName).toEqual(COUNTRY.name);
+    expect(topResult).toEqual(COUNTRY.name);
   });
 });

--- a/src/app/public/testing/country-field/country-field-fixture.ts
+++ b/src/app/public/testing/country-field/country-field-fixture.ts
@@ -61,9 +61,16 @@ export class SkyCountryFieldFixture {
   /**
    * Enters the search text into the input field displaying search results, but making no selection.
    * @param searchText The name of the country to select.
+   * @returns The list of country names matching the search text.
    */
-  public async search(searchText: string): Promise<NodeListOf<HTMLElement>> {
-    const results = await this.searchAndGetResults(searchText, this.fixture);
+  public async search(searchText: string): Promise<string[]> {
+    const resultNodes = await this.searchAndGetResults(searchText, this.fixture);
+    const resultArray = Array.prototype.slice.call(resultNodes);
+    const results = resultArray.map((result: HTMLElement) => {
+      const countryNameEl = result.querySelector('.sky-highlight-mark');
+      const countryName = SkyAppTestUtility.getText(countryNameEl);
+      return countryName;
+    });
 
     this.fixture.detectChanges();
     await this.fixture.whenStable();
@@ -75,7 +82,7 @@ export class SkyCountryFieldFixture {
    * Enters the search text into the input field and selects the first result (if any).
    * @param searchText The name of the country to select.
    */
-  public async searchAndSelectFirstResult(searchText: string): Promise<any> {
+  public async searchAndSelectFirstResult(searchText: string): Promise<void> {
     await this.searchAndSelect(searchText, 0, this.fixture);
 
     this.fixture.detectChanges();
@@ -85,7 +92,7 @@ export class SkyCountryFieldFixture {
   /**
    * Clears the country selection and input field.
    */
-  public clear(): Promise<any> {
+  public clear(): Promise<void> {
     this.enterSearch('', this.fixture);
 
     this.fixture.detectChanges();
@@ -107,7 +114,7 @@ export class SkyCountryFieldFixture {
     return debugEl.nativeElement as HTMLTextAreaElement;
   }
 
-  private blurInput(fixture: ComponentFixture<any>): Promise<any> {
+  private blurInput(fixture: ComponentFixture<any>): Promise<void> {
     SkyAppTestUtility.fireDomEvent(this.getInputElement(), 'blur');
     fixture.detectChanges();
     return fixture.whenStable();
@@ -116,7 +123,7 @@ export class SkyCountryFieldFixture {
   private enterSearch(
     newValue: string,
     fixture: ComponentFixture<any>
-  ): Promise<any> {
+  ): Promise<void> {
     const inputElement = this.getInputElement();
     inputElement.value = newValue;
 
@@ -137,7 +144,7 @@ export class SkyCountryFieldFixture {
     newValue: string,
     index: number,
     fixture: ComponentFixture<any>
-  ): Promise<any> {
+  ): Promise<void> {
     const inputElement = this.getInputElement();
     const searchResults = await this.searchAndGetResults(newValue, fixture);
 


### PR DESCRIPTION
Update the country field fixture to return an array of country names during searches instead of exposing the internal DOM to consumers. 
Also don't set the expectation that promises return anything other than void when using whenStable().