### PR TITLE
Release 5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.2 (2021-10-14)
+
+- Added support for wrapping lookup in a CSS class. [#230](https://github.com/blackbaud/skyux-lookup/pull/230)
+
 # 5.0.1 (2021-10-13)
 
 - Fixed lookup component to allow for setting the value programatically when the component is disabled. [#222](https://github.com/blackbaud/skyux-lookup/pull/222) (Thanks [@ThomasOrtiz](https://github.com/ThomasOrtiz)!)

--- a/projects/lookup/package.json
+++ b/projects/lookup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/lookup",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "peerDependencies": {
     "@angular/common": "^12.2.10",
     "@angular/core": "^12.2.10",


### PR DESCRIPTION
- Added support for wrapping lookup in a CSS class. [#230](https://github.com/blackbaud/skyux-lookup/pull/230)
